### PR TITLE
Improved: Added productStoreId in ItemVarianceDetails view (#2)

### DIFF
--- a/entity/OmsInventoryViewEntities.xml
+++ b/entity/OmsInventoryViewEntities.xml
@@ -42,6 +42,12 @@ under the License.
         <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F">
             <key-map field-name="facilityTypeId"/>
         </member-entity>
+        <member-entity entity-alias="SSP" entity-name="co.hotwax.shopify.ShopifyShopProduct" join-from-alias="PR" join-optional="true">
+            <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="SS" entity-name="co.hotwax.shopify.ShopifyShop" join-from-alias="SSP" join-optional="true">
+            <key-map field-name="shopId"/>
+        </member-entity>
 
         <alias-all entity-alias="PI"/>
         <alias-all entity-alias="IIV"/>
@@ -60,5 +66,6 @@ under the License.
 
         <alias entity-alias="PR" name="productId"/>
         <alias entity-alias="PR" name="productTypeId"/>
+        <alias entity-alias="SS" name="productStoreId"/>
     </view-entity>
 </entities>


### PR DESCRIPTION
Closes #2 

1. Added productStoreId in the ItemVarianceDetails View, so that brand-wise feeds can be generated.
2. Added relation of Product with ShopifyShopProduct on the productId field.
3. Added relation of ShopifyShopProduct with ShopifyShop on the shopId field.