### PR TITLE
Improved: Included product type entity in Shopify Product Inventory View (#27)

### DIFF
--- a/entity/OmsShopifyViewEntities.xml
+++ b/entity/OmsShopifyViewEntities.xml
@@ -49,6 +49,10 @@ under the License.
         <member-entity entity-alias="FG" entity-name="org.apache.ofbiz.product.facility.FacilityGroup" join-from-alias="FGM" join-optional="true">
             <key-map field-name="facilityGroupId"/>
         </member-entity>
+        <member-entity entity-alias="PT" entity-name="org.apache.ofbiz.product.product.ProductType" join-from-alias="P" join-optional="true">
+            <key-map field-name="productTypeId"/>
+        </member-entity>
+
         <alias entity-alias="SS" name="productStoreId"/>
         <alias entity-alias="SSP" name="productId"/>
         <alias entity-alias="SSP" name="shopifyProductId"/>
@@ -85,6 +89,10 @@ under the License.
              Due to this, if threshold is updated for a product, the feed will not pick it up as a change
              since that record is not included in the view, And so updated inventory does not get pushed to
              Shopify. -->
+        <alias entity-alias="PT" name="productTypeId"/>
+        <alias entity-alias="PT" name="isPhysical"/>
+        <alias entity-alias="PT" name="isDigital"/>
+
         <entity-condition>
             <econditions combine="or">
                 <econdition field-name="facilityGroupTypeId" value="SHOPIFY_GROUP_FAC"/>


### PR DESCRIPTION
Joined product type entity in Shopify Product Inventory view.
This change is required to get the Product type id and isPhysical check in Shopify Inventory feed service.