### PR TITLE
Improved: Added Product Internal Name field in BrokeredOrderItemSyncQueue view

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -264,6 +264,7 @@ under the License.
         <alias entity-alias="OS" name="statusDatetime"/>
         <alias entity-alias="PD" name="productId"/>
         <alias entity-alias="PD" name="productTypeId"/>
+        <alias entity-alias="PD" name="internalName"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="ODR" field="partyId" name="customerPartyId"/>
         <entity-condition>


### PR DESCRIPTION
Closes #59 
1. Added Internal name field from Product entity in BrokeredOrderItemSyncQueue view.
2. Product entity already existed in the view, so only a filed is added.
