### PR TITLE
Added: Delivery related date and time in Brokered Order Items Sync Queue view

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -252,6 +252,9 @@ under the License.
         <alias entity-alias="OI" name="unitPrice"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OI" name="itemDescription"/>
+        <alias entity-alias="OI" name="requestedDeliveryDate"/>
+        <alias entity-alias="OI" name="requestedDeliveryTime"/>
+        <alias entity-alias="OI" name="deliveryWindow"/>
         <alias entity-alias="OISG" name="shipGroupSeqId"/>
         <alias entity-alias="OISG" name="shipmentMethodTypeId"/>
         <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>


### PR DESCRIPTION
closes #99

Added the following fields in the Brokered Order Items Sync Queue

1. requestedDeliveryDate
2. requestedDeliveryTime
3. deliveryWindow
