### PR TITLE
Improved: Order Item and Shipment Partial Fulfillment view

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -732,6 +732,9 @@ under the License.
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="OI">
             <key-map field-name="orderId"/>
         </member-entity>
+        <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OH" join-optional="true">
+            <key-map field-name="orderId"/>
+        </member-entity>
         <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
             <key-map field-name="salesChannelEnumId" related="enumId"/>
         </member-entity>
@@ -810,10 +813,12 @@ under the License.
         <alias entity-alias="OH" name="orderId"/>
         <alias entity-alias="OH" name="orderName"/>
         <alias entity-alias="OH" name="orderDate"/>
+        <alias entity-alias="OH" name="orderTypeId"/>
         <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
         <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" name="entryDate"/>
         <alias entity-alias="OH" name="grandTotal"/>
+        <alias entity-alias="SSO" name="shopId"/>
         <alias entity-alias="UOM" field="abbreviation" name="currency"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -733,9 +733,6 @@ under the License.
         <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="OI">
             <key-map field-name="orderId"/>
         </member-entity>
-        <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OH" join-optional="true">
-            <key-map field-name="orderId"/>
-        </member-entity>
         <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
             <key-map field-name="salesChannelEnumId" related="enumId"/>
         </member-entity>
@@ -819,7 +816,6 @@ under the License.
         <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" name="entryDate"/>
         <alias entity-alias="OH" name="grandTotal"/>
-        <alias entity-alias="SSO" name="shopId"/>
         <alias entity-alias="UOM" field="abbreviation" name="currency"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -716,10 +716,11 @@ under the License.
     </view-entity>
 
     <!-- TODO: This view entity can be removed in future when a new order item will be created for remaining quantities of an order item in new Shipment
-         in case of Partial Fulfillment Explode-off scenario. The existing view OrderItemAndShipment can be reused here. 
-    This view is used for fetching the Shipment Details for the Fulfilled Order Items with partial Fulfillment.
+         in case of Partial Fulfillment Explode-off scenario. The existing views FulfilledOrderItemsSyncQueue and OrderItemAndShipment can be used in place
+         of it.
+    This view is used for both purposes fetch the Fulfilled Order Item details and fetch the Shipment Details for the Fulfilled Order Items.
     NOTE:
-    1. It is being used to prepare the Feed for Fulfilled Order Items along with the view FulfilledOrderItemsSyncQueue.
+    1. It is being used to prepare the Feed for Fulfilled Order Items.
     2. This includes the use of OrderFulfillmentHistory entity to get only those fulfilled order items shipment wise for which history is not created.
     3. It is used to handle the scenario of explode-off in which an item can be included in multiple Shipments if its quantity is greater than 1.
        Here, Order Item Ship Group Assoc is removed and ship group seq id is directly fetched from Order Item.


### PR DESCRIPTION
1. Updated Order Item and Shipment Partial Fulfillment view entity to include order level details like shopId and orderTypeId.
2. Now this view can be used in place of Fulfilled Order Sync View to fetch Fulfilled Orders details in Fulfilled Order Items Feed.