### PR TITLE
View entity to fetch Order Item and Attributes in the Get Order API lookup HotWax to Predict Spring

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -742,6 +742,27 @@ under the License.
         <alias entity-alias="SRS" name="shipmentRouteSegmentId"/>
         <alias entity-alias="SPRS" name="trackingNumber" field="trackingCode"/>
     </view-entity>
+
+    <!-- View entity to fetch Order Item and Attribute details. -->
+    <view-entity entity-name="OrderItemAndAttribute" package="co.hotwax.financial" group="ofbiz_transactional">
+        <description>View to fetch the Order Item and Item Attribute Details.</description>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+        <member-entity entity-alias="OIA" entity-name="org.apache.ofbiz.order.order.OrderItemAttribute" join-from-alias="OI" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <alias entity-alias="OI" name="orderId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" field="statusId" name="orderItemStatus"/>
+        <alias entity-alias="OI" name="productId"/>
+        <alias entity-alias="OI" name="quantity" function="sum"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
+        <alias entity-alias="OI" name="orderItemTypeId"/>
+        <alias-all entity-alias="OIA">
+            <exclude field="orderId"/>
+            <exclude field="orderItemSeqId"/>
+        </alias-all>
+    </view-entity>
 </entities>
 
 


### PR DESCRIPTION
1. We need to send the Store Associate details to Predict Spring along with the Order details, in HC Store Associate details are stored in the Order Item Attribute entity.
2. In the Get Order API, we need to prepare the details as per the product since we need to send the total quantity of the product to Predict Spring.
3. In the Order Item Attribute entity, there is no support for product ID, and due to this, while fetching the details of the Store Associate from Order Item Attribute, we are not getting the result as expected.
4. To address this issue, we created a view entity that will include the Order Item and Order Item Attribute entity. By this approach, we can fetch the details for the specific product.