### PR TITLE
View entity to fetch Facility and Facility Group Member details

### DIFF
--- a/entity/OmsShopifyViewEntities.xml
+++ b/entity/OmsShopifyViewEntities.xml
@@ -147,4 +147,27 @@ under the License.
             <date-filter from-field-name="productStoreFacilityFromDate" thru-field-name="productStoreFacilityThruDate"/>
         </entity-condition>
    </view-entity>
+
+    <view-entity entity-name="FacilityGroupAndMember" package="co.hotwax.facility" group="ofbiz_transactional">
+        <description>
+            View entity for Facility and Facility Group Member details.
+        </description>
+        <member-entity entity-alias="FG" entity-name="org.apache.ofbiz.product.facility.FacilityGroup"/>
+        <member-entity entity-alias="FGM" entity-name="org.apache.ofbiz.product.facility.FacilityGroupMember" join-from-alias="FG">
+            <key-map field-name="facilityGroupId"/>
+        </member-entity>
+        <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="FGM">
+            <key-map field-name="facilityId"/>
+        </member-entity>
+        <alias-all entity-alias="FG"/>
+        <alias-all entity-alias="FGM">
+            <exclude field="facilityGroupId"/>
+            <exclude field="fromDate"/>
+        </alias-all>
+        <alias-all entity-alias="F">
+            <exclude field="facilityId"/>
+            <exclude field="description"/>
+        </alias-all>
+        <alias entity-alias="FGM" name="fromDate" function="max"/>
+    </view-entity>
 </entities>

--- a/entity/OmsShopifyViewEntities.xml
+++ b/entity/OmsShopifyViewEntities.xml
@@ -162,12 +162,10 @@ under the License.
         <alias-all entity-alias="FG"/>
         <alias-all entity-alias="FGM">
             <exclude field="facilityGroupId"/>
-            <exclude field="fromDate"/>
         </alias-all>
         <alias-all entity-alias="F">
             <exclude field="facilityId"/>
             <exclude field="description"/>
         </alias-all>
-        <alias entity-alias="FGM" name="fromDate" function="max"/>
     </view-entity>
 </entities>


### PR DESCRIPTION
1. This view entity is necessary for the Shopify Inventory feed, where we require Configuration facility IDs for specific Facility Groups.

Here is the parent issue for the reference:- [issue-1036](https://git.hotwax.co/HC2/plugins/ofbiz-oms-usl/-/issues/1036) , [#note_197161](https://git.hotwax.co/HC2/plugins/ofbiz-oms-usl/-/merge_requests/435#note_197161)

Closes https://github.com/hotwax/ofbiz-oms-udm/issues/139