### PR TITLE
Added: Order Item External ID in the Return Item View entity

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -139,6 +139,7 @@ under the License.
         <alias entity-alias="RI" name="productId"/>
         <alias entity-alias="RI" name="returnReasonNote" field="reason"/>
         <alias entity-alias="OI" name="orderItemRequestedShipMethTypeId" field="requestedShipMethTypeId"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
 
         <alias entity-alias="OH" name="orderName"/>
 


### PR DESCRIPTION
This requirement is encountered while preparing the response of the Get Orders API.

In the Get Orders API response, from HotWax to Predict Spring, we need to prepare the details based on the products.

While fetching the Return Items using their product IDs, we are not getting the correct details if the order is of the mixed cart type.

For example, order DT00001198 has three items, all associated with the same UPC. Two items are fulfilled in-store, and the other item is of the send sale type. In this scenario, we will have the same product ID for all these items, so if we fetch the returns using only product ID then in the result we will get the sum of the quantity. But in the API response, we need to send individual details of the return items for the send sale item and the in-store type of items.

To address this issue we must include the order item external ID of the order to differentiate the send sale item and the in-store type of items.