### PR TITLE
Improved: FinancialReturnItemsSyncQueue view to remove checks on return status

### DIFF
--- a/entity/OmsFinancialViewEntities.xml
+++ b/entity/OmsFinancialViewEntities.xml
@@ -41,6 +41,7 @@ under the License.
         <member-entity entity-alias="RS" entity-name="org.apache.ofbiz.order.return.ReturnStatus" join-from-alias="RI">
             <key-map field-name="returnId"/>
             <key-map field-name="returnItemSeqId"/>
+            <key-map field-name="statusId"/>
         </member-entity>
         <member-entity entity-alias="RH" entity-name="org.apache.ofbiz.order.return.ReturnHeader" join-from-alias="RI">
             <key-map field-name="returnId"/>
@@ -64,7 +65,7 @@ under the License.
         <alias entity-alias="RI" name="orderId"/>
         <alias entity-alias="RI" name="orderItemSeqId" />
         <alias entity-alias="RI" name="returnItemAmountTotal" field="returnPrice"/>
-        <alias entity-alias="RS" name="statusId" />
+        <alias entity-alias="RI" name="statusId" />
         <alias entity-alias="RS" name="completedDatetime" field="statusDatetime" function="max"/>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderName"/>
@@ -74,8 +75,6 @@ under the License.
         <alias entity-alias="RH" name="customerPartyId" field="fromPartyId"/>
         <entity-condition>
             <econditions>
-                <econdition entity-alias="RS" field-name="statusId" operator="equals" value="RETURN_COMPLETED"/>
-                <econdition entity-alias="RI" field-name="statusId" operator="equals" value="RETURN_COMPLETED"/>
                 <econdition entity-alias="RS" field-name="returnItemSeqId" operator="not-equals" value=""/>
                 <econdition entity-alias="FRH" field-name="returnId" operator="equals" value=""/>
             </econditions>


### PR DESCRIPTION
This is done to have the view generic, and corresponding condition to fetch only completed return items can be added in the service using the view