### PR TITLE
Added: Product ID, Return Adjustment ID and Order Item External ID in the ReturnItemAndAdjustment View

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -380,18 +380,25 @@ under the License.
             <key-map field-name="returnId"/>
             <key-map field-name="returnItemSeqId"/>
         </member-entity>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="RI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
         <alias entity-alias="RI" name="returnId"/>
         <alias entity-alias="RI" name="returnItemSeqId"/>
         <alias entity-alias="RI" name="orderId"/>
         <alias entity-alias="RI" name="orderItemSeqId"/>
         <alias entity-alias="RI" name="returnPrice"/>
         <alias entity-alias="RI" name="returnQuantity"/>
+        <alias entity-alias="RI" name="productId"/>
         <alias entity-alias="RS" name="statusId" />
         <alias entity-alias="RS" name="completedDatetime" field="statusDatetime" function="max"/>
+        <alias entity-alias="RA" name="returnAdjustmentId"/>
         <alias entity-alias="RA" name="returnAdjustmentTypeId"/>
         <alias entity-alias="RA" name="comments"/>
         <alias entity-alias="RA" name="description"/>
         <alias entity-alias="RA" name="amount" function="sum"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <entity-condition>
             <econditions>
                 <econdition entity-alias="RS" field-name="returnItemSeqId" operator="not-equals" value=""/>


### PR DESCRIPTION
Closes https://github.com/hotwax/ofbiz-oms-udm/issues/148


This requirement is encountered while preparing the response of the Get Orders API.

In the Get Orders API response, from HotWax to Predict Spring, we need to prepare the details based on the products.

While fetching the order adjustments for the products using their product IDs, we are not getting the correct details if the order is of the mixed cart type.

For example, order DT00001198 has three items, all associated with the same UPC. Two items are fulfilled in-store, and the other item is of the send sale type. In this scenario, we will have the same product ID for all these items, so if we fetch the adjustments using only product ID then in the result we will get the sum of all the adjustment amount. But in the API response we need to send individual details of the adjustments for the send sale item and the in-store type of items.

To address this issue we must include the order item external ID of the order to differentiate the send sale item and the in-store type of items.