### PR TITLE
Added the required fields in the SalesOrderView needed in the FulfilledOrderItemsFeed

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -48,12 +48,6 @@ under the License.
         <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH" join-optional="true">
             <key-map field-name="currencyUom" related="uomId"/>
         </member-entity>
-        <member-entity entity-alias="ODR" entity-name="org.apache.ofbiz.order.order.OrderRole" join-from-alias="OH" join-optional="true">
-            <key-map field-name="orderId"/>
-        </member-entity>
-        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
-            <key-map field-name="partyId"/>
-        </member-entity>
         <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OH" join-optional="true">
             <key-map field-name="orderId"/>
         </member-entity>
@@ -78,6 +72,7 @@ under the License.
         <alias entity-alias="OI" name="unitPrice"/>
         <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
         <alias entity-alias="OI" name="productId"/>
+        <alias entity-alias="OI" name="cancelQuantity"/>
 
         <alias entity-alias="OISG" name="facilityId"/>
         <alias entity-alias="OISG" field="contactMechId" name="shipToPostalContactMechId"/>
@@ -92,9 +87,6 @@ under the License.
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
 
         <alias entity-alias="UOM" field="abbreviation" name="currency"/>
-        <alias entity-alias="ODR" name="partyId"/>
-        <alias entity-alias="P" field="firstName" name="customerFirstName"/>
-        <alias entity-alias="P" field="lastName" name="customerLastName"/>
         <alias entity-alias="SSO" name="shopId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
     </view-entity>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -69,7 +69,7 @@ under the License.
         <alias entity-alias="OH" name="grandTotal"/>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderDate"/>
-        <alias entity-alias="OH" name="statusId"/>
+        <alias entity-alias="OH" name="statusId" name="orderStatusId"/>
         <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" name="orderTypeId"/>
         <alias entity-alias="OH" name="entryDate"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -54,11 +54,6 @@ under the License.
         <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
             <key-map field-name="salesChannelEnumId" related="enumId"/>
         </member-entity>
-        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="statusId"/>
-        </member-entity>
         <member-entity entity-alias="P" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
             <key-map field-name="productId"/>
         </member-entity>
@@ -103,8 +98,6 @@ under the License.
 
         <alias entity-alias="PT" name="isPhysical"/>
         <alias entity-alias="PT" name="isDigital"/>
-        <alias entity-alias="OS" name="statusDatetime" function="max"/>
-
     </view-entity>
 
     <view-entity entity-name="AppeasementView" package="co.hotwax.financial" group="ofbiz_transactional">

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -69,7 +69,7 @@ under the License.
         <alias entity-alias="OH" name="grandTotal"/>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderDate"/>
-        <alias entity-alias="OH" name="statusId" name="orderStatusId"/>
+        <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
         <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" name="orderTypeId"/>
         <alias entity-alias="OH" name="entryDate"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -54,6 +54,17 @@ under the License.
         <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
             <key-map field-name="salesChannelEnumId" related="enumId"/>
         </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="statusId"/>
+        </member-entity>
+        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
+            <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="PT" entity-name="org.apache.ofbiz.product.product.ProductType" join-from-alias="P" join-optional="true">
+            <key-map field-name="productTypeId"/>
+        </member-entity>
 
         <alias entity-alias="OISGA" name="orderId"/>
         <alias entity-alias="OISGA" name="orderItemSeqId"/>
@@ -89,6 +100,11 @@ under the License.
         <alias entity-alias="UOM" field="abbreviation" name="currency"/>
         <alias entity-alias="SSO" name="shopId"/>
         <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
+
+        <alias entity-alias="PT" name="isPhysical"/>
+        <alias entity-alias="PT" name="isDigital"/>
+        <alias entity-alias="OS" name="statusDatetime" function="max"/>
+
     </view-entity>
 
     <view-entity entity-name="AppeasementView" package="co.hotwax.financial" group="ofbiz_transactional">

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -45,6 +45,21 @@ under the License.
         <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F" join-optional="true">
             <key-map field-name="facilityTypeId"/>
         </member-entity>
+        <member-entity entity-alias="UOM" entity-name="org.apache.ofbiz.common.uom.Uom" join-from-alias="OH" join-optional="true">
+            <key-map field-name="currencyUom" related="uomId"/>
+        </member-entity>
+        <member-entity entity-alias="ODR" entity-name="org.apache.ofbiz.order.order.OrderRole" join-from-alias="OH" join-optional="true">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
+            <key-map field-name="partyId"/>
+        </member-entity>
+        <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OH" join-optional="true">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="SCENM" entity-name="org.apache.ofbiz.common.enum.Enumeration" join-from-alias="OH" join-optional="true">
+            <key-map field-name="salesChannelEnumId" related="enumId"/>
+        </member-entity>
 
         <alias entity-alias="OISGA" name="orderId"/>
         <alias entity-alias="OISGA" name="orderItemSeqId"/>
@@ -52,6 +67,12 @@ under the License.
 
         <alias entity-alias="OH" name="orderName"/>
         <alias entity-alias="OH" name="grandTotal"/>
+        <alias entity-alias="OH" name="productStoreId"/>
+        <alias entity-alias="OH" name="orderDate"/>
+        <alias entity-alias="OH" name="statusId"/>
+        <alias entity-alias="OH" name="orderExternalId"/>
+        <alias entity-alias="OH" name="orderTypeId"/>
+        <alias entity-alias="OH" name="entryDate"/>
 
         <alias entity-alias="OI" name="quantity"/>
         <alias entity-alias="OI" name="unitPrice"/>
@@ -69,6 +90,13 @@ under the License.
         <alias entity-alias="F" name="facilityTypeId"/>
         <alias entity-alias="F" field="externalId" name="facilityExternalId"/>
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
+
+        <alias entity-alias="UOM" field="abbreviation" name="currency"/>
+        <alias entity-alias="ODR" name="partyId"/>
+        <alias entity-alias="P" field="firstName" name="customerFirstName"/>
+        <alias entity-alias="P" field="lastName" name="customerLastName"/>
+        <alias entity-alias="SSO" name="shopId"/>
+        <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
     </view-entity>
 
     <view-entity entity-name="AppeasementView" package="co.hotwax.financial" group="ofbiz_transactional">

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -70,7 +70,7 @@ under the License.
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="OH" name="orderDate"/>
         <alias entity-alias="OH" name="statusId"/>
-        <alias entity-alias="OH" name="orderExternalId"/>
+        <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" name="orderTypeId"/>
         <alias entity-alias="OH" name="entryDate"/>
 


### PR DESCRIPTION
In this PR,  
Added Uom, ShopifyShopOrder, Enumeration, Product, ProductType entities in the SalesOrderView and fields that needed to generate the fulfilled order items feed for Shopify/ERP.