### PR TITLE
Added views for Fulfilled Order Items for Shopify

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -1306,7 +1306,7 @@ under the License.
             </econditions>
             <!-- TODO facing issue when using in this view, need to debug and check
                     Unknown column 'SOV.ENTRY_DATE' in 'order clause' -->
-            <!--            <order-by field-name="entryDate"/>-->
+<!--            <order-by field-name="entryDate"/>-->
         </entity-condition>
     </view-entity>
 

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -899,7 +899,6 @@ under the License.
         <alias entity-alias="SRS" name="actualCarrierCode"/>
     </view-entity>
 
-
     <!--Adding the view-entity to fetch the eligible order items for sending fulfilled order items info for Shopify.
      1. Scenario of ADOC
          1.1 Fulfilled Order Items Feed for Shopify, this contains a check on Item Status to be completed as it should be item wise.
@@ -916,12 +915,18 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="statusId"/>
+        </member-entity>
         <alias entity-alias="OI" name="orderId"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias-all entity-alias="SOV">
             <exclude field="orderId"/>
             <exclude field="orderItemSeqId"/>
         </alias-all>
+        <alias entity-alias="OS" name="statusDatetime" function="max"/>
         <entity-condition>
             <econditions combine="and">
                 <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
@@ -943,12 +948,18 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="statusId"/>
+        </member-entity>
         <alias entity-alias="OI" name="orderId"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias-all entity-alias="OISDV">
             <exclude field="orderId"/>
             <exclude field="orderItemSeqId"/>
         </alias-all>
+        <alias entity-alias="OS" name="statusDatetime" function="max"/>
         <entity-condition>
             <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
         </entity-condition>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -899,13 +899,9 @@ under the License.
         <alias entity-alias="SRS" name="actualCarrierCode"/>
     </view-entity>
 
-    <!--Adding the view-entity to fetch the eligible order items for sending fulfilled order items info for Shopify.
-     1. Scenario of ADOC
-         1.1 Fulfilled Order Items Feed for Shopify, this contains a check on Item Status to be completed as it should be item wise.
-         1.2 Fulfilled Order Items Feed for ERP (for GL Posting/Invoicing), this contains a check on Order Status to be completed as it should be sent when the entire order is completed.
-     2. In this view we are handling the case of Shopify.
+    <!-- New view is added to fetch the eligible orders to be send in the fulfilment feed for Shopify
      -->
-    <view-entity entity-name="FulfilledOrdersItemsForShopify" package="co.hotwax.warehouse">
+    <view-entity entity-name="FulfilledOrdersItemsForShopify" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
         <member-entity entity-alias="SOV" entity-name="co.hotwax.financial.SalesOrderView" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderItemSeqId"/>
@@ -938,9 +934,9 @@ under the License.
         </entity-condition>
     </view-entity>
 
-    <view-entity entity-name="OrderItemShipmentForShopify" package="co.hotwax.warehouse">
+    <view-entity entity-name="OrderItemShipmentForShopify" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
-        <member-entity entity-alias="OISDV" entity-name="co.hotwax.warehouse.OrderItemAndShipmentDetailsView" sub-select="true" join-from-alias="OI">
+        <member-entity entity-alias="OISD" entity-name="co.hotwax.warehouse.OrderItemShipmentDetail" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
@@ -955,7 +951,7 @@ under the License.
         </member-entity>
         <alias entity-alias="OI" name="orderId"/>
         <alias entity-alias="OI" name="orderItemSeqId"/>
-        <alias-all entity-alias="OISDV">
+        <alias-all entity-alias="OISD">
             <exclude field="orderId"/>
             <exclude field="orderItemSeqId"/>
         </alias-all>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -954,6 +954,7 @@ under the License.
         <alias-all entity-alias="OISD">
             <exclude field="orderId"/>
             <exclude field="orderItemSeqId"/>
+            <exclude field="statusDatetime"/>
         </alias-all>
         <alias entity-alias="OS" name="statusDatetime" function="max"/>
         <entity-condition>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -962,6 +962,10 @@ under the License.
         <alias entity-alias="OS" name="statusDatetime" function="max"/>
         <entity-condition>
             <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
+            <econditions combine="or">
+                <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
+            </econditions>
         </entity-condition>
     </view-entity>
 </entities>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -903,6 +903,7 @@ under the License.
      -->
     <view-entity entity-name="FulfilledOrdersItemsForShopify" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+         <!-- TODO sub-select is used here, but needs to be revisted for query performance and efficiency -->
         <member-entity entity-alias="SOV" entity-name="co.hotwax.financial.SalesOrderView" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderItemSeqId"/>
             <key-map field-name="orderId"/>
@@ -936,6 +937,7 @@ under the License.
 
     <view-entity entity-name="OrderItemShipmentForShopify" package="co.hotwax.warehouse" group="ofbiz_transactional">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+        <!-- TODO sub-select is used here, but needs to be revisted for query performance and efficiency -->
         <member-entity entity-alias="OISD" entity-name="co.hotwax.warehouse.OrderItemShipmentDetail" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -905,7 +905,7 @@ under the License.
          1.2 Fulfilled Order Items Feed for ERP (for GL Posting/Invoicing), this contains a check on Order Status to be completed as it should be sent when the entire order is completed.
      2. In this view we are handling the case of Shopify.
      -->
-    <view-entity entity-name="FulfilledOrdersView" package="co.hotwax.warehouse">
+    <view-entity entity-name="FulfilledOrdersItemsForShopify" package="co.hotwax.warehouse">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
         <member-entity entity-alias="SOV" entity-name="co.hotwax.financial.SalesOrderView" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderItemSeqId"/>
@@ -938,7 +938,7 @@ under the License.
         </entity-condition>
     </view-entity>
 
-    <view-entity entity-name="FulfilledOrderItemsView" package="co.hotwax.warehouse">
+    <view-entity entity-name="OrderItemShipmentForShopify" package="co.hotwax.warehouse">
         <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
         <member-entity entity-alias="OISDV" entity-name="co.hotwax.warehouse.OrderItemAndShipmentDetailsView" sub-select="true" join-from-alias="OI">
             <key-map field-name="orderId"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -898,6 +898,61 @@ under the License.
         <alias entity-alias="SPRS" name="trackingNumber" field="trackingCode"/>
         <alias entity-alias="SRS" name="actualCarrierCode"/>
     </view-entity>
+
+
+    <!--Adding the view-entity to fetch the eligible order items for sending fulfilled order items info for Shopify.
+     1. Scenario of ADOC
+         1.1 Fulfilled Order Items Feed for Shopify, this contains a check on Item Status to be completed as it should be item wise.
+         1.2 Fulfilled Order Items Feed for ERP (for GL Posting/Invoicing), this contains a check on Order Status to be completed as it should be sent when the entire order is completed.
+     2. In this view we are handling the case of Shopify.
+     -->
+    <view-entity entity-name="FulfilledOrdersView" package="co.hotwax.warehouse">
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+        <member-entity entity-alias="SOV" entity-name="co.hotwax.financial.SalesOrderView" sub-select="true" join-from-alias="OI">
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OI" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <alias entity-alias="OI" name="orderId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias-all entity-alias="SOV">
+            <exclude field="orderId"/>
+            <exclude field="orderItemSeqId"/>
+        </alias-all>
+        <entity-condition>
+            <econditions combine="and">
+                <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
+                <econditions combine="or">
+                    <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                    <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
+                </econditions>
+            </econditions>
+        </entity-condition>
+    </view-entity>
+
+    <view-entity entity-name="FulfilledOrderItemsView" package="co.hotwax.warehouse">
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+        <member-entity entity-alias="OISDV" entity-name="co.hotwax.warehouse.OrderItemAndShipmentDetailsView" sub-select="true" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OI" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <alias entity-alias="OI" name="orderId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias-all entity-alias="OISDV">
+            <exclude field="orderId"/>
+            <exclude field="orderItemSeqId"/>
+        </alias-all>
+        <entity-condition>
+            <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
+        </entity-condition>
+    </view-entity>
 </entities>
 
 


### PR DESCRIPTION
In this PR, 
Added FulfilledOrdersItemsForShopify and OrderItemShipmentForShopify view. this view is required to fetch the eligible orders for the fulfilled items feed for Shopify. 