### PR TITLE
Improved: Refactored views to get Order Item Adjustment and Item Attributes with Item details

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -937,25 +937,20 @@ under the License.
         <alias entity-alias="RI" field="statusId" name="returnItemStatus"/>
     </view-entity>
 
-    <!-- View entity to fetch Order Item and Attribute details. -->
-    <view-entity entity-name="OrderItemAndAttribute" package="co.hotwax.financial" group="ofbiz_transactional">
-        <description>View to fetch the Order Item and Item Attribute Details.</description>
-        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
-        <member-entity entity-alias="OIA" entity-name="org.apache.ofbiz.order.order.OrderItemAttribute" join-from-alias="OI" join-optional="true">
+    <view-entity entity-name="OrderAttributeAndItem" package="co.hotwax.financial" group="ofbiz_transactional">
+        <description>View to fetch the Order Item Attributes including some item details.</description>
+        <member-entity entity-alias="OIA" entity-name="org.apache.ofbiz.order.order.OrderItemAttribute"/>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OIA">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
-        <alias entity-alias="OI" name="orderId"/>
-        <alias entity-alias="OI" name="orderItemSeqId"/>
-        <alias entity-alias="OI" field="statusId" name="orderItemStatus"/>
+
+        <alias-all entity-alias="OIA"/>
+        <alias entity-alias="OI" name="statusId"/>
         <alias entity-alias="OI" name="productId"/>
-        <alias entity-alias="OI" name="quantity" function="sum"/>
+        <alias entity-alias="OI" name="quantity"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OI" name="orderItemTypeId"/>
-        <alias-all entity-alias="OIA">
-            <exclude field="orderId"/>
-            <exclude field="orderItemSeqId"/>
-        </alias-all>
     </view-entity>
 
     <view-entity entity-name="OrderItemDetail" package="co.hotwax.order" group="ofbiz_transactional">
@@ -1041,20 +1036,20 @@ under the License.
             <key-map field-name="returnId"/>
         </member-entity>
 
-        <alias entity-alias="RI" name="returnId"/>
-        <alias entity-alias="RI" name="returnItemSeqId"/>
+        <alias entity-alias="RA" name="returnId"/>
+        <alias entity-alias="RA" name="returnItemSeqId"/>
+        <alias entity-alias="RA" name="returnAdjustmentId"/>
+        <alias entity-alias="RA" name="returnAdjustmentTypeId"/>
+        <alias entity-alias="RA" name="comments"/>
+        <alias entity-alias="RA" name="description"/>
+        <alias entity-alias="RA" name="amount" function="sum"/>
+
         <alias entity-alias="RI" name="orderId"/>
         <alias entity-alias="RI" name="orderItemSeqId"/>
         <alias entity-alias="RI" name="returnPrice"/>
         <alias entity-alias="RI" name="returnQuantity"/>
         <alias entity-alias="RI" name="productId"/>
         <alias entity-alias="RI" name="statusId" />
-
-        <alias entity-alias="RA" name="returnAdjustmentId"/>
-        <alias entity-alias="RA" name="returnAdjustmentTypeId"/>
-        <alias entity-alias="RA" name="comments"/>
-        <alias entity-alias="RA" name="description"/>
-        <alias entity-alias="RA" name="amount" function="sum"/>
 
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
 
@@ -1076,6 +1071,8 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
+        <alias entity-alias="OA" name="orderId"/>
+        <alias entity-alias="OA" name="orderItemSeqId"/>
         <alias entity-alias="OA" name="orderAdjustmentId"/>
         <alias entity-alias="OA" name="orderAdjustmentTypeId"/>
         <alias entity-alias="OA" name="comments"/>
@@ -1084,8 +1081,6 @@ under the License.
         <alias entity-alias="OA" name="amount" function="sum"/>
         <alias entity-alias="OA" name="sourceReferenceId"/>
 
-        <alias entity-alias="OI" name="orderId"/>
-        <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" name="productId"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OI" name="unitPrice"/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -1068,39 +1068,21 @@ under the License.
         </entity-condition>
     </view-entity>
 
-    <!-- View entity to fetch Order Item Adjustments and Attributes. -->
-    <!-- NOTE: OrderItemAndAdjustment view entity is already exist to fetch the Order Item Adjustments, but in the Get Orders API there is a requirement to prepare the
-         Order Item Adjustments along with Order Adjustments Attributes. Hence, a new entity OrderItemAdjustmentAndAttribute is created for this purpose.
-         This is required to prevent issues with existing code, as the OrderItemAndAdjustment view is already used to fetch the Order Item Adjustments in the feeds. -->
-    <!-- TODO: Check if necessary fields can be added to the existing view and verify the feeds, if everything looks good then use the existing OrderItemAndAdjustment view to simplify things. -->
-
-    <view-entity entity-name="OrderItemAdjustmentAndAttribute" package="co.hotwax.order" group="ofbiz_transactional">
-        <description>View to get the Order Items and their Adjustments.</description>
-        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
-        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderStatus" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="statusId"/>
-        </member-entity>
-        <member-entity entity-alias="OA" entity-name="org.apache.ofbiz.order.order.OrderAdjustment" join-from-alias="OI" join-optional="true">
+    <!-- View entity to fetch Order Adjustment and Item Details -->
+    <!-- NOTE: In the Get Orders API for integration with PS, there is a requirement to prepare the
+         Order Item Adjustments per product. This new entity is created for this purpose.
+         Facility ID is also required, so included OISG also -->
+    <view-entity entity-name="OrderAdjustmentAndItem" package="co.hotwax.order" group="ofbiz_transactional">
+        <description>View to get the Order Item Adjustments and and item details.</description>
+        <member-entity entity-alias="OA" entity-name="org.apache.ofbiz.order.order.OrderAdjustment"/>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OA" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
-        <member-entity entity-alias="OAA" entity-name="org.apache.ofbiz.order.order.OrderAdjustmentAttribute" join-from-alias="OA" join-optional="true">
-            <key-map field-name="orderAdjustmentId"/>
-        </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-        <alias entity-alias="OI" name="orderId"/>
-        <alias entity-alias="OI" name="orderItemSeqId"/>
-        <alias entity-alias="OI" name="productId"/>
-        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
-        <alias entity-alias="OI" name="unitPrice"/>
-        <alias entity-alias="OI" name="quantity"/>
-        <alias entity-alias="OS" name="statusId" />
-        <alias entity-alias="OS" field="statusDatetime" name="completedDatetime"/>
         <alias entity-alias="OA" name="orderAdjustmentId"/>
         <alias entity-alias="OA" name="orderAdjustmentTypeId"/>
         <alias entity-alias="OA" name="comments"/>
@@ -1108,15 +1090,16 @@ under the License.
         <alias entity-alias="OA" name="description"/>
         <alias entity-alias="OA" name="amount" function="sum"/>
         <alias entity-alias="OA" name="sourceReferenceId"/>
-        <alias entity-alias="OAA" name="attrName"/>
-        <alias entity-alias="OAA" name="attrValue"/>
+
+        <alias entity-alias="OI" name="orderId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" name="productId"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
+        <alias entity-alias="OI" name="unitPrice"/>
+        <alias entity-alias="OI" name="quantity"/>
+        <alias entity-alias="OI" name="statusId" />
+
         <alias entity-alias="OISG" name="facilityId"/>
-        <entity-condition>
-            <econditions>
-                <econdition entity-alias="OS" field-name="orderItemSeqId" operator="not-equals" value=""/>
-            </econditions>
-            <order-by field-name="completedDatetime"/>
-        </entity-condition>
     </view-entity>
 </entities>
 

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -948,7 +948,7 @@ under the License.
         <alias-all entity-alias="OIA"/>
         <alias entity-alias="OI" name="statusId"/>
         <alias entity-alias="OI" name="productId"/>
-        <alias entity-alias="OI" name="quantity"/>
+        <alias entity-alias="OI" name="quantity" function="sum"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
         <alias entity-alias="OI" name="orderItemTypeId"/>
     </view-entity>


### PR DESCRIPTION
1. Renamed view from OrderItemAdjustmentAndAttribute to OrderAdjustmentAndItem
2. Primary entity is now OrderAdjustment instead of staring from OrderItem
3. Removed the joins with OrderStatus and OrderAdjustmentAttribute as not required and not efficient way respectively
4. Improved some alias for Order item and return item adjustment views.
5. Renamed view from OrderItemAndAttribute to OrderAttributeAndItem as part of refactoring done.