### PR TITLE
Improved: excluded virtual facility orders in Brokered Orders Items Sync View

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -295,7 +295,7 @@ under the License.
         <entity-condition>
             <econditions combine="and">
                 <econdition entity-alias="OH" field-name="orderTypeId" operator="equals" value="SALES_ORDER"/>
-                <econdition entity-alias="OISG" field-name="facilityId" operator="not-equals" value="_NA_"/>
+                <econdition entity-alias="FT" field-name="parentTypeId" operator="not-equals" value="VIRTUAL_FACILITY"/>
                 <econditions combine="or">
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value="REJECT"/>
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>


### PR DESCRIPTION
1. Improved: replaced facility not equals _NA_ check with parent type id not equals Virtual Facility in Brokered Order Items Sync Queue view to exclude orders from ineligible facilities in Brokered Orders feed.