### PR TITLE
Improved: included order facility id in Order Item and Shipment view

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -727,6 +727,7 @@ under the License.
         <alias entity-alias="OISG" field="shipmentMethodTypeId" name="slaShipmentMethodTypeId"/>
         <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>
         <alias entity-alias="OISG" name="telecomContactMechId"/>
+        <alias entity-alias="OISG" name="orderFacilityId"/>
         <alias entity-alias="OISGA" field="quantity" name="itemQuantity"/>
         <alias entity-alias="F" name="facilityId"/>
         <alias entity-alias="F" field="externalId" name="facilityExternalId"/>


### PR DESCRIPTION
1. We need to include the order facility id in the Fulfilled Order Items feed so included this field in the Order Item and Shipment view.