### PR TITLE
Improved: Added createDate and createdByUserLoginId column in InventoryCountImportItem table (#215).

### DIFF
--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -825,6 +825,7 @@ under the License.
         <field name="productIdentifier" type="id-long"></field>
         <field name="quantity" type="number-decimal"></field>
         <field name="countedByUserLoginId" type="id"></field>
+        <field name="createdDate" type="date-time"></field>
         <relationship type="one" fk-name="INV_COUNT_IMPORT" related="co.hotwax.warehouse.InventoryCountImport">
             <key-map field-name="inventoryCountImportId"/>
         </relationship>

--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -826,6 +826,7 @@ under the License.
         <field name="quantity" type="number-decimal"></field>
         <field name="countedByUserLoginId" type="id"></field>
         <field name="createdDate" type="date-time"></field>
+        <field name="createdByUserLoginId" type="id"></field>
         <relationship type="one" fk-name="INV_COUNT_IMPORT" related="co.hotwax.warehouse.InventoryCountImport">
             <key-map field-name="inventoryCountImportId"/>
         </relationship>


### PR DESCRIPTION
Added createdDate and createdByUserLoginId columns in InventoryCountImportItem table. As some NiFi flows are dependant on the "Created Stamp" (auto generated field of OFBiz) field and from new Cycle count app (based on Moqui) it is not set.