### PR TITLE
Improved: Added importItemSeqId field in InvCountImportStatus entity in order to start tracking item level status change

### DIFF
--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -686,6 +686,7 @@ under the License.
         <field name="invCountImpStatusId" type="id" is-pk="true"></field>
         <field name="statusId" type="id"></field>
         <field name="inventoryCountImportId" type="id"></field>
+        <field name="importItemSeqId" type="id"></field>
         <field name="statusDate" type="date-time"></field>
         <field name="changeByUserLoginId" type="id-long"></field>
         <relationship type="one" fk-name="INV_COUNT_IMP_STTS" related="org.apache.ofbiz.common.status.StatusItem">
@@ -693,6 +694,10 @@ under the License.
         </relationship>
         <relationship type="one" fk-name="INV_COUNT_IMPT" related="co.hotwax.warehouse.InventoryCountImport">
             <key-map field-name="inventoryCountImportId"/>
+        </relationship>
+        <relationship type="one-nofk" related="co.hotwax.warehouse.InventoryCountImportItem">
+            <key-map field-name="inventoryCountImportId"/>
+            <key-map field-name="importItemSeqId"/>
         </relationship>
         <relationship type="one" fk-name="INV_CNT_STTS_USRLN" title="ChangeBy" related="org.apache.ofbiz.security.login.UserLogin">
             <key-map field-name="changeByUserLoginId" related="userLoginId"/>
@@ -707,7 +712,6 @@ under the License.
         <field name="productIdentifier" type="id-long"></field>
         <field name="quantity" type="number-decimal"></field>
         <field name="countedByUserLoginId" type="id-long"></field>
-        <field name="acceptedByUserLoginId" type="id-long"></field>
         <field name="createdDate" type="date-time"></field>
         <field name="createdByUserLoginId" type="id-long"></field>
         <relationship type="one" fk-name="INV_COUNT_IMPORT" related="co.hotwax.warehouse.InventoryCountImport">

--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -706,9 +706,10 @@ under the License.
         <field name="productId" type="id"></field>
         <field name="productIdentifier" type="id-long"></field>
         <field name="quantity" type="number-decimal"></field>
-        <field name="countedByUserLoginId" type="id"></field>
+        <field name="countedByUserLoginId" type="id-long"></field>
+        <field name="acceptedByUserLoginId" type="id-long"></field>
         <field name="createdDate" type="date-time"></field>
-        <field name="createdByUserLoginId" type="id"></field>
+        <field name="createdByUserLoginId" type="id-long"></field>
         <relationship type="one" fk-name="INV_COUNT_IMPORT" related="co.hotwax.warehouse.InventoryCountImport">
             <key-map field-name="inventoryCountImportId"/>
         </relationship>


### PR DESCRIPTION
Done following - 
1) Added importItemSeqId field in InvCountImportStatus entity in order to start tracking item level status change.
2) Corrected createdByUserLoginId and countedByUserLoginId field type to match the UserLogin.userLoginId field.