### PR TITLE
Added the field 'countImportName' to the view entity 'InventoryCountImportVariance'

### DIFF
--- a/entity/OmsInventoryViewEntities.xml
+++ b/entity/OmsInventoryViewEntities.xml
@@ -88,6 +88,7 @@ under the License.
         </member-entity>
         <alias entity-alias="ICI" name="inventoryCountImportId"/>
         <alias entity-alias="ICI" name="facilityId"/>
+        <alias entity-alias="ICI" name="countImportName"/>
         <!-- This is the current statusId from InventoryCountImport -->
         <alias entity-alias="ICI" name="statusId"/>
         <alias entity-alias="ICII" field="statusId" name="inventoryCountItemStatusId"/>


### PR DESCRIPTION
- Currently, when syncing inventory adjustments to NetSuite, we send Inventory cycle by HotWax  in the memo field. Instead, we need to send the count name in this field.