### PR TITLE
Order item ship group assoc removal

### DIFF
--- a/entity/DatamodelOrderEntitymodel.xml
+++ b/entity/DatamodelOrderEntitymodel.xml
@@ -476,7 +476,7 @@ under the License.
             <key-map field-name="orderItemSeqId"/>
         </relationship>
     </entity>
-    <entity entity-name="OrderItemShipGroup" package="org.apache.ofbiz.order.order">
+    <entity entity-name="OrderItemShipGroup" package="org.apache.ofbiz.order.order" sequence-secondary-padded-length="5">
         <field name="orderId" type="id" is-pk="true"></field>
         <field name="shipGroupSeqId" type="id" is-pk="true"></field>
         <field name="shipmentMethodTypeId" type="id" enable-audit-log="true"></field>

--- a/entity/DatamodelOrderEntitymodel.xml
+++ b/entity/DatamodelOrderEntitymodel.xml
@@ -74,11 +74,6 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </relationship>
-        <relationship type="one-nofk" related="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </relationship>
         <relationship type="one" fk-name="ORDER_ADJ_PRGEO" title="Primary" related="moqui.basic.Geo">
             <key-map field-name="primaryGeoId" related="geoId"/>
         </relationship>
@@ -339,11 +334,6 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </relationship>
-        <relationship type="one-nofk" title="From" related="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </relationship>
         <relationship type="one-nofk" title="From" related="org.apache.ofbiz.order.order.OrderItemShipGroup">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
@@ -354,11 +344,6 @@ under the License.
         <relationship type="one-nofk" title="To" related="org.apache.ofbiz.order.order.OrderItem">
             <key-map field-name="toOrderId" related="orderId"/>
             <key-map field-name="toOrderItemSeqId" related="orderItemSeqId"/>
-        </relationship>
-        <relationship type="one-nofk" title="To" related="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc">
-            <key-map field-name="toOrderId" related="orderId"/>
-            <key-map field-name="toOrderItemSeqId" related="orderItemSeqId"/>
-            <key-map field-name="toShipGroupSeqId" related="shipGroupSeqId"/>
         </relationship>
         <relationship type="one-nofk" title="To" related="org.apache.ofbiz.order.order.OrderItemShipGroup">
             <key-map field-name="toOrderId" related="orderId"/>
@@ -491,7 +476,7 @@ under the License.
             <key-map field-name="orderItemSeqId"/>
         </relationship>
     </entity>
-    <entity entity-name="OrderItemShipGroup" package="org.apache.ofbiz.order.order" sequence-secondary-padded-length="5">
+    <entity entity-name="OrderItemShipGroup" package="org.apache.ofbiz.order.order">
         <field name="orderId" type="id" is-pk="true"></field>
         <field name="shipGroupSeqId" type="id" is-pk="true"></field>
         <field name="shipmentMethodTypeId" type="id" enable-audit-log="true"></field>
@@ -551,7 +536,7 @@ under the License.
             <key-map field-name="telecomContactMechId" related="contactMechId"/>
         </relationship>
     </entity>
-    <entity entity-name="OrderItemShipGroupAssoc" package="org.apache.ofbiz.order.order">
+    <entity entity-name="OldOrderItemShipGroupAssoc" package="org.apache.ofbiz.order.order" table-name="ORDER_ITEM_SHIP_GROUP_ASSOC">
         <field name="orderId" type="id" is-pk="true"></field>
         <field name="orderItemSeqId" type="id" is-pk="true"></field>
         <field name="shipGroupSeqId" type="id" is-pk="true"></field>
@@ -569,6 +554,7 @@ under the License.
             <key-map field-name="shipGroupSeqId"/>
         </relationship>
     </entity>
+    <!-- TODO: skipped element view-entity -->
     <entity entity-name="OrderItemShipGrpInvRes" package="org.apache.ofbiz.order.order" cache="never">
         <field name="orderId" type="id" is-pk="true"></field>
         <field name="shipGroupSeqId" type="id" is-pk="true"></field>
@@ -593,11 +579,6 @@ under the License.
         </relationship>
         <relationship type="one-nofk" related="org.apache.ofbiz.order.order.OrderItemShipGroup">
             <key-map field-name="orderId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </relationship>
-        <relationship type="one-nofk" related="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
             <key-map field-name="shipGroupSeqId"/>
         </relationship>
         <relationship type="one" fk-name="ORDER_ITIR_INVITM" related="org.apache.ofbiz.product.inventory.InventoryItem">
@@ -715,11 +696,6 @@ under the License.
         <relationship type="one-nofk" related="org.apache.ofbiz.shipment.shipment.ShipmentItem">
             <key-map field-name="shipmentId"/>
             <key-map field-name="shipmentItemSeqId"/>
-        </relationship>
-        <relationship type="one-nofk" related="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-            <key-map field-name="shipGroupSeqId"/>
         </relationship>
     </entity>
     <entity entity-name="OrderStatus" package="org.apache.ofbiz.order.order" cache="never">

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -24,15 +24,11 @@ under the License.
     <!-- NOTE: Not adding the billing details as they are not stored in OMS -->
     <view-entity entity-name="SalesOrderView" package="co.hotwax.financial">
         <description>View to get Order details for Financial Feed processing.</description>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc"></member-entity>
-        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="OISGA">
+        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
             <key-map field-name="orderId"/>
         </member-entity>
-        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OISGA">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
@@ -61,9 +57,9 @@ under the License.
             <key-map field-name="productTypeId"/>
         </member-entity>
 
-        <alias entity-alias="OISGA" name="orderId"/>
-        <alias entity-alias="OISGA" name="orderItemSeqId"/>
-        <alias entity-alias="OISGA" name="shipGroupSeqId"/>
+        <alias entity-alias="OH" name="orderId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" name="shipGroupSeqId"/>
 
         <alias entity-alias="OH" name="orderName"/>
         <alias entity-alias="OH" name="grandTotal"/>
@@ -213,18 +209,14 @@ under the License.
         <member-entity entity-alias="PRO" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
             <key-map field-name="productId"/>
         </member-entity>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
         <member-entity entity-alias="ORHD" entity-name="org.apache.ofbiz.order.order.OrderHeader" join-from-alias="OH">
             <key-map field-name="orderId"/>
         </member-entity>
-        <member-entity entity-alias="OISGIR" entity-name="org.apache.ofbiz.order.order.OrderItemShipGrpInvRes" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="OISGIR" entity-name="org.apache.ofbiz.order.order.OrderItemShipGrpInvRes" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
             <key-map field-name="shipGroupSeqId"/>
@@ -251,20 +243,16 @@ under the License.
         <member-entity entity-alias="SCENM" entity-name="moqui.basic.Enumeration" join-from-alias="OH" join-optional="true">
             <key-map field-name="salesChannelEnumId" related="enumId"/>
         </member-entity>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OISGINR" entity-name="org.apache.ofbiz.order.order.OrderItemShipGrpInvRes" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="OISGINR" entity-name="org.apache.ofbiz.order.order.OrderItemShipGrpInvRes" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-        <member-entity entity-alias="EFO" entity-name="co.hotwax.integration.order.ExternalFulfillmentOrderItem" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="EFO" entity-name="co.hotwax.integration.order.ExternalFulfillmentOrderItem" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
             <key-map field-name="shipGroupSeqId"/>
@@ -341,8 +329,8 @@ under the License.
                     <econdition entity-alias="EFO" field-name="fulfillmentStatus" operator="equals" value=""/>
                 </econditions>
                 <econditions combine="or">
-                    <econdition entity-alias="OISGA" field-name="quantity" operator="greater" to-entity-alias="OISGA" to-field-name="cancelQuantity"/>
-                    <econdition entity-alias="OISGA" field-name="cancelQuantity" operator="equals" value=""/>
+                    <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                    <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
                 </econditions>
                 <econdition entity-alias="ODR" field-name="roleTypeId" operator="equals" value="BILL_TO_CUSTOMER"/>
             </econditions>
@@ -549,11 +537,7 @@ under the License.
         <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OH" join-optional="true">
             <key-map field-name="orderId"/>
         </member-entity>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
@@ -562,7 +546,7 @@ under the License.
                      3. The shipGroupSeqId is not available in OrderFulfillmentHistory entity, this could have created possible issue for the scenario of explode OFF partial fulfillment
                      of an order Item as in that case shipGroupSeqId can be same.
                      4. This will not be an issue as discussed, for this scenario, new orderItem will be created for the remaining quantity for that item.  -->
-        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
@@ -603,7 +587,7 @@ under the License.
         <alias entity-alias="OISG" field="shipmentMethodTypeId" name="slaShipmentMethodTypeId"/>
         <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>
         <alias entity-alias="OISG" name="telecomContactMechId"/>
-        <alias entity-alias="OISGA" field="quantity" name="itemQuantity"/>
+        <alias entity-alias="OI" field="quantity" name="itemQuantity"/>
         <alias entity-alias="F" name="facilityId"/>
         <alias entity-alias="F" field="externalId" name="facilityExternalId"/>
         <alias entity-alias="FT" name="facilityTypeId"/>
@@ -619,8 +603,8 @@ under the License.
             <econditions combine="and">
                 <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
                 <econditions combine="or">
-                    <econdition entity-alias="OISGA" field-name="quantity" operator="greater" to-entity-alias="OISGA" to-field-name="cancelQuantity"/>
-                    <econdition entity-alias="OISGA" field-name="cancelQuantity" operator="equals" value=""/>
+                    <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                    <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
                 </econditions>
             </econditions>
             <order-by field-name="entryDate"/>
@@ -652,24 +636,20 @@ under the License.
         <member-entity entity-alias="P" entity-name="org.apache.ofbiz.party.party.Person" join-from-alias="ODR" join-optional="true">
             <key-map field-name="partyId"/>
         </member-entity>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OI">
-            <key-map field-name="orderId"/>
-            <key-map field-name="orderItemSeqId"/>
-        </member-entity>
         <!--  1. Previously, the join was added with the ExternalFulfillmentOrderItem entity using the fields orderId,orderItemSeqId,shipGroupSeqId.
                    2. Now the change is done to join with the OrderFulfillmentHistory entity using the fields orderId and orderItemSeqId.
                    3. The shipGroupSeqId is not available in OrderFulfillmentHistory entity, this could have created possible issue for the scenario of explode OFF partial fulfillment
                    of an order Item as in that case shipGroupSeqId can be same.
                    4. This will not be an issue as discussed, for this scenario, new orderItem will be created for the remaining quantity for that item.  -->
-        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="OFH" entity-name="co.hotwax.integration.order.OrderFulfillmentHistory" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OISGA">
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="shipGroupSeqId"/>
         </member-entity>
-        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OISGA" join-optional="true">
+        <member-entity entity-alias="OSH" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OI" join-optional="true">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
             <key-map field-name="shipGroupSeqId"/>
@@ -740,7 +720,7 @@ under the License.
         <alias entity-alias="OISG" field="contactMechId" name="postalContactMechId"/>
         <alias entity-alias="OISG" name="telecomContactMechId"/>
         <alias entity-alias="OISG" name="orderFacilityId"/>
-        <alias entity-alias="OISGA" field="quantity" name="itemQuantity"/>
+        <alias entity-alias="OI" field="quantity" name="itemQuantity"/>
         <alias entity-alias="F" name="facilityId"/>
         <alias entity-alias="F" field="externalId" name="facilityExternalId"/>
         <alias entity-alias="FT" name="facilityTypeId"/>
@@ -772,8 +752,8 @@ under the License.
             <econdition entity-alias="ODR" field-name="roleTypeId" operator="equals" value="BILL_TO_CUSTOMER"/>
             <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
             <econditions combine="or">
-                <econdition entity-alias="OISGA" field-name="quantity" operator="greater" to-entity-alias="OISGA" to-field-name="cancelQuantity"/>
-                <econdition entity-alias="OISGA" field-name="cancelQuantity" operator="equals" value=""/>
+                <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
             </econditions>
         </entity-condition>
     </view-entity>
@@ -1568,13 +1548,10 @@ under the License.
         </entity-condition>
     </view-entity>
 
+    <!--FIXME: This entity call should be replaced with OrderItemAndShipGroup -->
     <view-entity entity-name="OrderItemShipGroupAndAssoc" package="co.hotwax.warehouse">
-        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup"/>
-        <member-entity entity-alias="OISGA" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroupAssoc" join-from-alias="OISG">
-            <key-map field-name="orderId"/>
-            <key-map field-name="shipGroupSeqId"/>
-        </member-entity>
-        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OISGA">
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem"/>
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
@@ -1584,8 +1561,8 @@ under the License.
         <alias entity-alias="OISG" name="shipAfterDate"/>
         <alias entity-alias="OISG" name="shipmentMethodTypeId"/>
         <alias entity-alias="OISG" name="shipGroupSeqId"/>
-        <alias entity-alias="OISGA" name="quantity"/>
-        <alias entity-alias="OISGA" name="orderItemSeqId"/>
+        <alias entity-alias="OI" name="quantity"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
         <alias entity-alias="OI" name="autoCancelDate"/>
         <alias entity-alias="OI" name="productId"/>
         <alias entity-alias="OI" name="itemDescription"/>


### PR DESCRIPTION
https://github.com/hotwax/ofbiz-oms-udm/issues/269

From now on, the **`OrderItemShipGroupAssoc` database table is no longer the source of truth** for the order item and ship group relationship. It may contain **stale or missing data**.

**Update all custom SQL queries** and code references with the following mappings:

|Old Reference|New Mapping|
| --- | --- |
|`OrderItemShipGroupAssoc.orderId`|`OrderItem.orderId`|
|`OrderItemShipGroupAssoc.orderitemSeqId`|`OrderItem.itemSeqId`|
|`OrderItemShipGroupAssoc.quantity`|`OrderItem.quantity`|
|`OrderItemShipGroupAssoc.cancelQuantity`|`OrderItem.cancelQuantity`|
|`OrderItemShipGroupAssoc.shipGroupSeqId`|`OrderItem.shipGroupSeqId`|

> When joining with `OrderItemShipGroup`, use:

sql

```
ON OrderItem.orderId = OrderItemShipGroup.orderId
AND OrderItem.shipGroupSeqId = OrderItemShipGroup.shipGroupSeqId
```

