### PR TITLE
Included productTypeId field in ProductFacilityView view

### DIFF
--- a/entity/OmsInventoryViewEntities.xml
+++ b/entity/OmsInventoryViewEntities.xml
@@ -179,6 +179,7 @@ under the License.
         <alias entity-alias="F" name="defaultDaysToShip"/>
         <alias entity-alias="F" name="maximumOrderLimit"/>
         <alias entity-alias="P" name="internalName"/>
+        <alias entity-alias="P" name="productTypeId"/>
         <alias entity-alias="FT" name="parentFacilityTypeId" field="parentTypeId"/>
     </view-entity>
 </entities>


### PR DESCRIPTION
1. Used this view in generate TestTransferOrders services to only include Physical type goods, so that kit products do not get assigned to the TO Order Items.