### PR TITLE
Added the required Entities for the Shopify fulfillment sync flow

### DIFF
--- a/entity/HwmappsEntitymodel.xml
+++ b/entity/HwmappsEntitymodel.xml
@@ -1378,5 +1378,24 @@ under the License.
             <key-map field-name="receiptId"/>
         </relationship>
     </entity>
+
+    <entity entity-name="ShopifyFulfillmentHistory" package="co.hotwax.shopify">
+        <field name="fulfillmentLogId" type="id" is-pk="true"/>
+        <field name="orderId" type="id"/>
+        <field name="orderItemSeqId" type="id"/>
+        <field name="shipGroupSeqId" type="id"/>
+        <field name="shopId" type="id"/>
+        <field name="fulfillmentId" type="id"/>
+        <field name="createdDate" type="date-time"/>
+        <field name="comments" type="text-medium"/>
+
+        <relationship type="one" related="org.apache.ofbiz.order.order.OrderItem">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </relationship>
+        <relationship type="one" related="org.apache.ofbiz.order.order.OrderItemShipGroup"/>
+        <relationship type="one" related="co.hotwax.shopify.ShopifyShop"/>
+        <relationship type="one" related="co.hotwax.shopify.ShopifyShopOrder"/>
+    </entity>
 </entities>
 

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -1580,6 +1580,10 @@ under the License.
         <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OI">
             <key-map field-name="orderId"/>
         </member-entity>
+        <member-entity entity-alias="OISG" entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
         <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="OISG">
             <key-map field-name="facilityId"/>
         </member-entity>
@@ -1611,11 +1615,15 @@ under the License.
             <key-map field-name="orderId"/>
             <key-map field-name="orderItemSeqId"/>
         </member-entity>
+        <member-entity entity-alias="SCENM" entity-name="moqui.basic.Enumeration" join-from-alias="OH" join-optional="true">
+            <key-map field-name="salesChannelEnumId" related="enumId"/>
+        </member-entity>
         <alias entity-alias="F" name="facilityId" pq-expression=""/>
         <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
         <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
         <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
         <alias entity-alias="OH" name="orderId"/>
+        <alias entity-alias="OH" name="orderTypeId"/>
         <alias entity-alias="OH" name="productStoreId"/>
         <alias entity-alias="SSO" name="shopId"/>
         <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
@@ -1625,6 +1633,8 @@ under the License.
         <alias entity-alias="OI" name="shipGroupSeqId"/>
         <alias entity-alias="OI" field="productId" name="itemProductId"/>
         <alias entity-alias="SI" field="productId" name="shipmentProductId"/>
+        <alias entity-alias="FT" name="facilityTypeId"/>
+        <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
         <alias entity-alias="PT" name="isDigital"/>
         <alias entity-alias="PT" name="isPhysical"/>
         <alias entity-alias="S" field="statusId" name="shipmentStatusId"/>
@@ -1633,6 +1643,7 @@ under the License.
         <alias entity-alias="SRS" name="trackingIdNumber"/>
         <alias entity-alias="SRS" name="actualCarrierCode"/>
         <alias entity-alias="SRS" name="carrierPartyId"/>
+        <alias entity-alias="SCENM" field="enumCode" name="salesChannel"/>
         <entity-condition>
             <econditions combine="and">
                 <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>

--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -1572,4 +1572,76 @@ under the License.
         <alias entity-alias="OI" name="statusId"/>
     </view-entity>
 
+    <view-entity entity-name="ShopifyFulfilledOrderItemsQueue" package="co.hotwax.shopify">
+        <member-entity entity-alias="OH" entity-name="org.apache.ofbiz.order.order.OrderHeader"/>
+        <member-entity entity-alias="OI" entity-name="org.apache.ofbiz.order.order.OrderItem" join-from-alias="OH">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="SSO" entity-name="co.hotwax.shopify.ShopifyShopOrder" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+        </member-entity>
+        <member-entity entity-alias="F" entity-name="org.apache.ofbiz.product.facility.Facility" join-from-alias="OISG">
+            <key-map field-name="facilityId"/>
+        </member-entity>
+        <member-entity entity-alias="FT" entity-name="org.apache.ofbiz.product.facility.FacilityType" join-from-alias="F">
+            <key-map field-name="facilityTypeId"/>
+        </member-entity>
+        <member-entity entity-alias="P" entity-name="org.apache.ofbiz.product.product.Product" join-from-alias="OI">
+            <key-map field-name="productId"/>
+        </member-entity>
+        <member-entity entity-alias="PT" entity-name="org.apache.ofbiz.product.product.ProductType" join-from-alias="P">
+            <key-map field-name="productTypeId"/>
+        </member-entity>
+        <member-entity entity-alias="OS" entity-name="org.apache.ofbiz.order.order.OrderShipment" join-from-alias="OI">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+            <key-map field-name="shipGroupSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="SI" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentItem" join-from-alias="OS">
+            <key-map field-name="shipmentId"/>
+            <key-map field-name="shipmentItemSeqId"/>
+        </member-entity>
+        <member-entity entity-alias="S" entity-name="org.apache.ofbiz.shipment.shipment.Shipment" join-from-alias="OS">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
+        <member-entity entity-alias="SRS" entity-name="org.apache.ofbiz.shipment.shipment.ShipmentRouteSegment" join-from-alias="S">
+            <key-map field-name="shipmentId"/>
+        </member-entity>
+        <member-entity entity-alias="OFH" entity-name="co.hotwax.shopify.ShopifyFulfillmentHistory" join-from-alias="OI" join-optional="true">
+            <key-map field-name="orderId"/>
+            <key-map field-name="orderItemSeqId"/>
+        </member-entity>
+        <alias entity-alias="F" name="facilityId" pq-expression=""/>
+        <alias entity-alias="FT" field="parentTypeId" name="parentFacilityTypeId"/>
+        <alias entity-alias="OH" field="externalId" name="orderExternalId"/>
+        <alias entity-alias="OH" field="statusId" name="orderStatusId"/>
+        <alias entity-alias="OH" name="orderId"/>
+        <alias entity-alias="OH" name="productStoreId"/>
+        <alias entity-alias="SSO" name="shopId"/>
+        <alias entity-alias="OI" field="externalId" name="orderItemExternalId"/>
+        <alias entity-alias="OI" field="quantity" name="itemQuantity"/>
+        <alias entity-alias="OI" field="statusId" name="itemStatusId"/>
+        <alias entity-alias="OI" name="orderItemSeqId"/>
+        <alias entity-alias="OI" name="shipGroupSeqId"/>
+        <alias entity-alias="OI" field="productId" name="itemProductId"/>
+        <alias entity-alias="SI" field="productId" name="shipmentProductId"/>
+        <alias entity-alias="PT" name="isDigital"/>
+        <alias entity-alias="PT" name="isPhysical"/>
+        <alias entity-alias="S" field="statusId" name="shipmentStatusId"/>
+        <alias entity-alias="OS" name="shipmentId"/>
+        <alias entity-alias="S" name="shipmentTypeId"/>
+        <alias entity-alias="SRS" name="trackingIdNumber"/>
+        <alias entity-alias="SRS" name="actualCarrierCode"/>
+        <alias entity-alias="SRS" name="carrierPartyId"/>
+        <entity-condition>
+            <econditions combine="and">
+                <econdition entity-alias="OFH" field-name="orderId" operator="equals" value=""/>
+                <econditions combine="or">
+                    <econdition entity-alias="OI" field-name="quantity" operator="greater" to-entity-alias="OI" to-field-name="cancelQuantity"/>
+                    <econdition entity-alias="OI" field-name="cancelQuantity" operator="equals" value=""/>
+                </econditions>
+            </econditions>
+        </entity-condition>
+    </view-entity>
+
 </entities>

--- a/entity/OmsShopifyViewEntities.xml
+++ b/entity/OmsShopifyViewEntities.xml
@@ -183,4 +183,15 @@ under the License.
         <alias-all entity-alias="SHS"/>
         <alias-all entity-alias="SHL"/>
     </view-entity>
+
+    <view-entity entity-name="ShopifyShopAndProductStoreSetting" package="co.hotwax.shopify">
+        <member-entity entity-alias="SS" entity-name="co.hotwax.shopify.ShopifyShop"/>
+        <member-entity entity-alias="PSS" entity-name="org.apache.ofbiz.product.store.ProductStoreSetting" join-from-alias="SS">
+            <key-map field-name="productStoreId"/>
+        </member-entity>
+        <alias entity-alias="SS" name="shopId"/>
+        <alias entity-alias="SS" name="productStoreId"/>
+        <alias entity-alias="PSS" name="settingTypeEnumId"/>
+        <alias entity-alias="PSS" name="settingValue"/>
+    </view-entity>
 </entities>


### PR DESCRIPTION
### Added three entities
1. **ShopifyFulfillmentHistory**: physical entity to track the Shopify fulfillment history
2. **ShopifyFulfilledOrderItemsQueue**: To fetch the list of fulfilled order items that are not synced to Shopify
3. **ShopifyShopAndProductStoreSetting**: Product store settings for a ShopiftShop