### PR TITLE
Improvement: Updated the entity-alias to get the carrierPartyId from the Shipment Route Segment entity on the OrderItemAndShipment entity (315-update-alias-to-get-carrier-party-id)

### DIFF
--- a/entity/OmsOrderViewEntities.xml
+++ b/entity/OmsOrderViewEntities.xml
@@ -742,7 +742,7 @@ under the License.
         <alias entity-alias="SH" field="destinationTelecomNumberId" name="shipToTelecomContactMechId"/>
         <alias entity-alias="SH" name="shipmentTypeId"/>
         <alias entity-alias="SPRS" field="trackingCode" name="trackingNumber"/>
-        <alias entity-alias="SH" name="carrierPartyId"/>
+        <alias entity-alias="SRS" name="carrierPartyId"/>
         <alias entity-alias="SH" name="shipmentMethodTypeId"/>
         <alias entity-alias="PT" name="productTypeId"/>
         <alias entity-alias="PT" name="isPhysical"/>


### PR DESCRIPTION
Improvement: Updated the entity-alias to get the carrierPartyId from the Shipment Route Segment entity on the OrderItemAndShipment entity (315-update-alias-to-get-carrier-party-id)

Changelog: Changed